### PR TITLE
Fix pnpm init instructions

### DIFF
--- a/src/content/docs/guides/first-server.mdx
+++ b/src/content/docs/guides/first-server.mdx
@@ -32,7 +32,7 @@ npm init
 
 ```sh
 # create a new project with pnpm
-pnpm init .
+pnpm init
 ```
 
 </TabItem>


### PR DESCRIPTION
`pnpm init` doesn't take a `.` arg.

```
pnpm init .
 ERR_PNPM_INIT_ARG  init command does not accept any arguments
```