### PR TITLE
docs(services): provide working example of provideCompletionItems

### DIFF
--- a/src/content/docs/reference/services.mdx
+++ b/src/content/docs/reference/services.mdx
@@ -81,16 +81,21 @@ export const service = {
 	create(context): ServicePluginInstance {
 		return {
 			provideCompletionItems(document, position, token) {
-				return [
-					{
-						label: 'Hello',
-						kind: CompletionItemKind.Text,
-					},
-					{
-						label: 'World',
-						kind: CompletionItemKind.Text,
-					},
-				];
+				return {
+					isIncomplete: true,
+					items: [
+						{
+							label: 'Hello',
+							kind: CompletionItemKind.Text,
+							isIncomplete: false
+						},
+						{
+							label: 'World',
+							kind: CompletionItemKind.Text,
+							isIncomplete: false
+						},
+					]
+				}
 			},
 		};
 	},


### PR DESCRIPTION
```
"@volar/language-core": "~2.1.0",
		"@volar/language-server": "~2.1.0",
		"@volar/language-service": "~2.1.0",
		"volar-service-css": "volar-2.1",
		"volar-service-emmet": "volar-2.1",
		"volar-service-html": "volar-2.1",
		"volar-service-typescript": "volar-2.1",
		"vscode-html-languageservice": "^5.1.1",
```

Its complaining the types is incorrect, the changes resolved the issue